### PR TITLE
add autoreconf line

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ and GitHub's tools make merging your changes much more easy.
 
 Once checked out, the HaLVM utilizes a very traditional build process:
 
+> autoreconf
+
 > ./configure
 
 > make


### PR DESCRIPTION
Not sure if you intended to leave ./configure out of the repo, but if so, might be useful to let the casual reader know that you need to run 'autoreconf' to get it.
