### PR TITLE
Make re-installs easier by copying minlibc files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,8 @@ clean::
 
 install::
 	$(MAKE) -C halvm-ghc install ghclibdir=$(halvmlibdir)
-	$(CP) -rf halvm-ghc/rts/minlibc/include $(halvmlibdir)/include/minlibc
+	$(MKDIR) -p $(halvmlibdir)/include/minlibc
+	$(CP) -rf halvm-ghc/rts/minlibc/include/* $(halvmlibdir)/include/minlibc/
 
 ###############################################################################
 # HaLVM SCRIPTS ###############################################################


### PR DESCRIPTION
The previous method, copying directories, would appear to succeed the
first time only to have placed the header files in a subdirectory.  The
new method, copying the files within a directory, will overwrite
pre-existing include files.
