### PR TITLE
build: fix configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,12 +280,12 @@ AC_ARG_WITH(xen-tree,
  [INCLUDE_DIRS="$withval"
   CURDIR=`pwd`
   CPPFLAGS="${CPPFLAGS} -I${withval}/dist/install/usr/include"
-  LDFLAGS="${CPPFLAGS} -L${withval}/dist/install/usr/lib"
   AC_SUBST(XEN_INCLUDE_DIRECTORY,"${withval}/dist/install/usr/include")
   AC_SUBST(XEN_LIBRARY_DIRECTORY,"${withval}/dist/install/usr/lib")
   AC_SUBST(XEN_BIN_ROOT,"${withval}/dist/install/")],
  [AC_SUBST(XEN_BIN_ROOT,"/")
-  AC_SUBST(XEN_INCLUDE_DIRECTORY,"/usr/include")])
+  AC_SUBST(XEN_INCLUDE_DIRECTORY,"/usr/include")
+  AC_SUBST(XEN_LIBRARY_DIRECTORY,"/usr/lib")])
 
 dnl First, see if we have Xen around.
 AC_CHECK_HEADER(xen/xen.h,[],[


### PR DESCRIPTION
In my previous commit 8e5e8c18 ("build: search user supplied directory
for shared libraries") I accidently submitted a wrong version of my
patch, which breaks build without a user supplied Xen tree. This patch
fixes that bug.
