### PR TITLE
Improve the examples of Halfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ src/libIVC/libIVC.a
 
 src/misc/*.o
 src/profiling/convert-profile
+
+*.disk

--- a/examples/HighLevel/Halfs/Halfs.config
+++ b/examples/HighLevel/Halfs/Halfs.config
@@ -1,4 +1,4 @@
 name     = "Halfs"
 kernel   = "Halfs"
 memory   = 256
-# seclabel ='system_u:system_r:domU_t'
+disk     = [ "new.disk,raw,xvdp1,rw" ]

--- a/examples/HighLevel/Halfs/Halfs.hs
+++ b/examples/HighLevel/Halfs/Halfs.hs
@@ -1,10 +1,33 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings  #-}
 import System.Device.Memory
 import System.Device.ST
 import Control.Monad.ST (stToIO)
 import System.Device.BlockDevice
-import Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy as BL
 import Hypervisor.Debug
+import Data.Word
+import XenDevice.Disk
+import Hypervisor.XenStore
+import Halfs.CoreAPI
+import Halfs.Types
+import Halfs.Classes
+import Halfs.Errors
+import Halfs.HalfsState
+import Halfs.MonadUtils
+import Halfs.Utils
+import Halfs.Monad
+import Halfs.SuperBlock (SuperBlock)
+import Control.Monad.Reader
+import System.FilePath
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Hypervisor.Console
+import Hypervisor.ErrorCodes
+
+import Prelude hiding (getLine)
+
 
 {- ST
 main :: IO ()
@@ -21,10 +44,10 @@ main = do
         Nothing -> writeDebugConsole "device error"
 -}
 
--- {- Memory
+{- Memory
 main :: IO ()
 main = do
-    mbBlockDevice <- newMemoryBlockDevice 1024 512 -- Initialize a block device as ST
+    mbBlockDevice <- newMemoryBlockDevice 1024 512 -- Initialize a block device as Memory
     case mbBlockDevice of
         Just device -> do
 	    let wb = bdWriteBlock device
@@ -32,4 +55,119 @@ main = do
 	    bstring <- bdReadBlock device $ 512
 	    writeDebugConsole $ "String here: " ++ (BS.unpack bstring)
 	Nothing -> writeDebugConsole "device error"
+-}
 
+-- {- Disk
+-- Create a new in-memory block device, with the given number of
+-- sectors and sector size.
+
+newDiskBlockDevice :: Disk -> IO (Maybe (BlockDevice IO))
+newDiskBlockDevice disk = return $! Just BlockDevice {
+        bdBlockSize  = fromIntegral $ diskSectorSize disk
+      , bdNumBlocks  = fromIntegral $ diskSectors disk
+      , bdReadBlock  = \sector -> do
+            bl <- readDisk disk (fromIntegral $ diskSectorSize disk) (fromIntegral sector)
+            return $ bLtoBS bl
+      , bdWriteBlock = \sector bs -> writeDisk disk (bStoBL bs) $ fromIntegral sector
+      , bdFlush      = flushDiskCaches disk
+      , bdShutdown   = return ()
+      }
+
+bLtoBS :: BL.ByteString -> BS.ByteString
+bLtoBS = BS.concat . BL.toChunks
+bStoBL :: BS.ByteString -> BL.ByteString
+bStoBL bs = BL.fromChunks [bs]
+
+rwx = [Read, Write, Execute]
+defaultPerm = FileMode rwx rwx rwx
+
+main :: IO ()
+main = do
+    xs <- initXenStore
+    con <- initXenConsole
+    diskNames <- listDisks xs
+    writeDebugConsole $ "Disks: " ++ show diskNames ++ "\n"
+    case diskNames of
+      (diskName:_) -> do
+        disk <- openDisk xs diskName
+--        mdiskBD <- newDiskBlockDevice disk -- This is buggy, I need to tune it when I got some extra time
+        mdiskBD <- newMemoryBlockDevice 1024 1024
+        case mdiskBD of
+          Just diskBD -> do
+            fsState <- mountFS diskBD
+            
+            feedback <- runHalfs fsState $ do
+              mkdir "/" defaultPerm
+              return "/"
+            case feedback of
+              Right fp -> repl xs con fp fsState
+              Left err -> writeDebugConsole $ "Fail: " ++ show err ++ "\n"
+            unmountInfo <- runHalfs fsState unmount
+            case unmountInfo of
+              Left err -> writeDebugConsole $ "Error in unmounting: " ++ show err
+              Right () -> return ()
+          Nothing -> writeDebugConsole "Error in initializing disk block device!"
+      [] -> writeDebugConsole "No available disks!"
+
+newFS :: (Monad m, HalfsCapable b t r l m) => BlockDevice m -> m SuperBlock
+newFS diskBD = execNoEnv $ newfs diskBD 0 0 defaultPerm
+
+mountFS :: (Monad m, HalfsCapable b t r l m) => BlockDevice m -> m (HalfsState b r l m)
+mountFS diskBD = execNoEnv $ mount diskBD 0 0 defaultPerm
+
+execNoEnv :: Monad m => HalfsM b r l m a -> m a
+execNoEnv act = do
+  runHalfsNoEnv act >>= \ea -> case ea of
+    Left e  -> fail $ show e
+    Right x -> return x
+
+repl xs con here fsState = do
+  me <- xsGetDomId xs
+  writeConsole con ("Hello! This is an interactive Unix-like file-system shell for " ++
+                    show me ++ "\n")
+  writeConsole con ("Valid commands: quit, ls, cd, mkdir\n\n")
+  writeDebugConsole "Starting interaction loop!\n"
+  info <- runHalfs fsState $ loop con here
+  return ()
+
+loop con here = do
+  lift $ writeConsole con (here ++ "> ")
+  inquery <- lift $ getLine con
+  case words inquery of
+    ("quit":_) -> return ()
+    ("ls"  :_) -> do
+      handle <- openDir here
+      dirInfo <- readDir handle
+      lift $ writeConsole con $ printDir dirInfo ++ "\n"
+      loop con here
+    ("cd"  :x:_) -> do
+      case x of
+        ".." -> loop con (takeDirectory here)
+        d    -> do
+          handle <- openDir here
+          dirInfo <- readDir handle
+          if (filter (== d) $ map fst dirInfo) /= [] then
+            loop con (here </> d)
+            else do
+                 lift $ writeConsole con "No such directory\n"
+                 loop con here
+    ("mkdir":x:_) -> do
+      if x /= ".." then mkdir (here </> x) defaultPerm
+        else lift $ writeConsole con "Invalid directory name\n"
+      loop con here
+    _ -> do
+      lift $ writeConsole con "Unrecognized command\n"
+      loop con here
+
+getLine :: Console -> IO String
+getLine con = do
+  nextC <- readConsole con 1
+  writeConsole con nextC
+  case nextC of
+    "\r" -> writeConsole con "\n" >> return ""
+    [x]  -> (x:) `fmap` getLine con
+    _    -> fail "More than one character back?"
+
+printDir [] = ""
+printDir (x:[]) = fst x
+printDir (x:xs) = fst x ++ "\t" ++ printDir xs

--- a/examples/HighLevel/Halfs/Makefile
+++ b/examples/HighLevel/Halfs/Makefile
@@ -1,10 +1,10 @@
 BINARIES=Halfs
 include ../../standard.mk
 
-run: $(BINARIES)
-	sudo xl create $(BINARIES).config
+run: new.disk Halfs
+	sudo xl create Halfs.config
 	sleep 1
 	sudo xl dmesg -c
 
-mkdisk:
-	dd if=/dev/zero of=new.disk bs=1 count=1 seek=64M
+new.disk:
+	dd if=/dev/zero of=$@ bs=1M count=64

--- a/examples/HighLevel/Halfs/Makefile
+++ b/examples/HighLevel/Halfs/Makefile
@@ -1,7 +1,10 @@
 BINARIES=Halfs
 include ../../standard.mk
 
-run: Halfs
-	sudo xl create Halfs.config
+run: $(BINARIES)
+	sudo xl create $(BINARIES).config
 	sleep 1
 	sudo xl dmesg -c
+
+mkdisk:
+	dd if=/dev/zero of=new.disk bs=1 count=1 seek=64M

--- a/examples/HighLevel/Halfs/README.md
+++ b/examples/HighLevel/Halfs/README.md
@@ -1,14 +1,18 @@
 Halfs Examples
 ===
 
-## Library
-This is intended to be used when Halfs's HaLVM compatible branch is built and installed to HaLVM.
-
-Checkout the [main branch of Halfs]()
-
-Checkout the [HaLVM version of Halfs]()
+## Library-Support
+You need to go to [Halfs](https://github.com/GaloisInc/halfs) and installed the top-level library `Halfs` with `halvm-cabal install`.
 
 After installation, you can `make` and `make run` here like other examples.
 
-## Examples
-Due to the lack of file system, so although the `File.hs` is reserved in `System/Device`, it will not be used. Instead, we will use the memory backed block device model as well as the ST-backed. They are all arrays of memory in fact, to simulate the FS concepts such as "sectors" etc.
+## Structure
+The sole script `Halfs.hs` contains three sections:
+
+1. ST Monad Based Block Device RW Check
+2. Memory Monad Based Block Device RW Check
+3. `XenDevice.Disk` Based Simple Unix-Style File System Shell
+
+When you compile one of them, commented out others.
+
+Some `Halfs` interfaces, esp. `Flush` and `Shutdown` are mostly left empty. You might be interested to fix this bugs.

--- a/examples/standard.mk.in
+++ b/examples/standard.mk.in
@@ -7,13 +7,17 @@ ifeq ($(THREADED),y)
 THR_RT_OPT := -threaded
 endif
 
+ifeq ($(PROFILING),y)
+PROFILE_OPT := -prof
+endif
+
 all: $(BINARIES)
 
 clean::
 	rm -f $(BINARIES) *.hi *.o
 
 %: %.hs
-	halvm-ghc $(THR_RT_OPT) --make -o $@ $^
+	halvm-ghc $(THR_RT_OPT) $(PROFILE_OPT) --make -o $@ $^
 
 %: %.c
 	gcc -o $@ $^ -I$(IVC_INC) -lxenctrl -lcrypto -lxenstore $(IVC_LIB)/libIVC.a


### PR DESCRIPTION
This added the support for using `XenDevice.Disk` with the updated Halfs library, as well as a minimal interactive shell.

B.T.W. I checked the `examples/XenDivice` and found that there existed a Halfs example before. But I can't find the related commits in the repo history. Would someone like to point it out and maybe explain a little what happened at that time?

Thank you