### PR TITLE
Workaround for Cabal sandbox bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,10 @@ $1_BIN := $$(BUILDBOX)/bin/$2
 $$($1_BIN): $$(PLATCABAL) | $$($1_SRC)
 	$$(BUILDENV) && cd $$($1_SRC) && \
 		$$(CABAL) sandbox init --sandbox $$(BUILDBOX) && \
-		$$(CABAL) install
+                $$(CABAL) install --only-dep && \
+                $$(CABAL) configure && \
+                $$(CABAL) build && \
+                $$(CABAL) copy
 endef
 $(eval $(call hackage-sandbox-build,ALEX,alex))
 $(eval $(call hackage-sandbox-build,HAPPY,happy))

--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ You'll need these dependencies:
 
 > autoconf gcc automake libtool patch ncurses-devel xen-devel zlib-devel
 
-Additionally, make sure `alex >= 3.1` and `happy >= 1.19` are installed and
-in your PATH. This is a workaround for a 
-[Cabal bug](https://github.com/haskell/cabal/issues/2462).
-
 If GHC 7.8.4 is not present, a version of it will be downloaded for
 use during the build process.
 


### PR DESCRIPTION
Looks like this fixes the bootstrapping problem and happy
is no longer a build requirement.

Closes #53
Closes #54