### PR TITLE
Point halvm-ghc to halvm branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "halvm-ghc"]
 	path = halvm-ghc
 	url = git://github.com/GaloisInc/halvm-ghc.git
-	branch = wip-halvm-ghc-8.0
+	branch = halvm
 [submodule "src/openlibm"]
 	path = src/openlibm
 	url = git://github.com/acw/openlibm


### PR DESCRIPTION
Since the `wip-halvm-ghc-8.0` was merged in https://github.com/GaloisInc/halvm-ghc/commit/b17b3f2d616ced1c101ce4bcba635b5d19dab89d, think it's appropriate to point to `halvm` cc @acw @izgzhen 