### PR TITLE
Make finding bash a little more portable

### DIFF
--- a/src/scripts/halvm-cabal.in
+++ b/src/scripts/halvm-cabal.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 bindir=@bindir@

--- a/src/scripts/halvm-config.in
+++ b/src/scripts/halvm-config.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@

--- a/src/scripts/halvm-ghc-pkg.in
+++ b/src/scripts/halvm-ghc-pkg.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # BANNERSTART
 # - Copyright 2006-2008, Galois, Inc.
 # - This software is distributed under a standard, three-clause BSD license.

--- a/src/scripts/halvm-ghc.in
+++ b/src/scripts/halvm-ghc.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # BANNERSTART
 # - Copyright 2006-2008, Galois, Inc.
 # - This software is distributed under a standard, three-clause BSD license.

--- a/src/scripts/hsc2hs.in
+++ b/src/scripts/hsc2hs.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@

--- a/src/scripts/ldkernel.in
+++ b/src/scripts/ldkernel.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # hdkernel - a linker for HALVM
 # Usage: to be invoked from ghc using "ghc -pgml ldkernel"
 #


### PR DESCRIPTION
@ntc2, NixOS seems to have issues patching `#!/bin/bash`, but `#!/usr/bin/env bash` seems to patchable. 