### PR TITLE
updated HACKING.MD

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -14,9 +14,9 @@ Our Host OS of choice is **Fedora Server 22 or newer**. (Why "Server"? Because "
 
 You can download its image from any mirror site, for example:
 
-- For Server 22: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Server/x86_64/iso/Fedora-Server-DVD-x86_64-22.iso
-- For Server 23: https://download.fedoraproject.org/pub/fedora/linux/releases/23/Server/x86_64/iso/Fedora-Server-DVD-x86_64-23.iso
-- For Server 24: https://download.fedoraproject.org/pub/fedora/linux/releases/24/Server/x86_64/iso/Fedora-Server-dvd-x86_64-24-1.2.iso
+- For Server 22: https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/22/Server/x86_64/iso/Fedora-Server-DVD-x86_64-22.iso
+- For Server 23: https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/23/Server/x86_64/iso/Fedora-Server-DVD-x86_64-23.iso
+- For Server 24: https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/24/Server/x86_64/iso/Fedora-Server-dvd-x86_64-24-1.2.iso
 - For Server 25: https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/iso/Fedora-Server-dvd-x86_64-25-1.3.iso 
 - For Server 26: https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso 
 


### PR DESCRIPTION
updated links to fedora server images for Fedora Server 22,23,24 
if you try to download with older links it will fail as the images are now moved to fedora archives